### PR TITLE
Make Wake logic for determining file names match Scala logic.

### DIFF
--- a/build.wake
+++ b/build.wake
@@ -100,6 +100,12 @@ global def getRocketChipGeneratorOutputsAllOutputs      = getRocketChipGenerator
 global def getRocketChipGeneratorOutputsInputOptions    = getRocketChipGeneratorOutputsInputOptions_
 global def getRocketChipGeneratorOutputsObjectModelFile = getRocketChipGeneratorOutputsOMFile_
 
+# Get the package name from the fully-qualified class name. (Everything before the final dot.)
+def getPackageName fullClassName = fullClassName | tokenize `\.` | reverse | tail | reverse | catWith "."
+
+# Get the class name from the fully-qualified class name. (Everything after the final dot.)
+def getClassName fullClassName = fullClassName | tokenize `\.` | reverse | head | getOrElse ""
+
 global def runRocketChipGenerator options =
   def jars = options.getRocketChipGeneratorOptionsJars
   def runDir = "rocket-chip"
@@ -139,12 +145,12 @@ global def runRocketChipGenerator options =
 
   def allOutputs = generatorJob.getJobOutputs
   def baseFileName = match options.getRocketChipGeneratorOptionsBaseFileName
-    Some fileName = fileName.quote, `\.anno\.json`, Nil
+    Some fileName = fileName
     None =
-      def topModuleName = options.getRocketChipGeneratorOptionsTopModuleName
-      def packageName = topModuleName | tokenize `\.` | reverse | tail | reverse | catWith "."
-      packageName.quote, `.*\.anno\.json`, Nil
-  def annoFile    = getFile (regExpCat (`.*`, baseFileName))
+      def packageName = getPackageName options.getRocketChipGeneratorOptionsTopModuleName
+      def configNames = options.getRocketChipGeneratorOptionsConfigNames | map getClassName | catWith '_'
+      "{packageName}.{configNames}"
+  def annoFile    = getFile (regExpCat (`.*`, baseFileName.quote, `\.anno\.json`, Nil))
   def firrtlFile  = getFile `.*\.fir`
   def romConfFile = getFile `.*\.rom\.conf`
   def dtsFile     = getFile `.*\.dts`


### PR DESCRIPTION
This PR merges into https://github.com/chipsalliance/rocket-chip/pull/2413. This more accurately computes the default base file name when none are specified, which involve taking the names of all the configs and combining them with the package corresponding to the top module.

/cc @debs-sifive, @albertchen-sifive, @mwachs5, @RajeshVaradharajan